### PR TITLE
Fixed 'production' mode script to run in both windows and linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "gulp",
-    "production": "NODE_ENV=production gulp"
+    "production": "set NODE_ENV=production&& gulp"
   },
   "author": "Daniel Belohlavek",
   "license": "MIT",


### PR DESCRIPTION
Made the 'production' mode script command compatible with both a windows and linux standard command line processors.

Tested in Win7Ult and Ubuntu 14.04