### PR TITLE
Specify paths to avoid relative imports

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var del = require('del');
 var gulp = require('gulp');
+var path = require('path');
 var argv = require('yargs').argv;
 var gutil = require('gulp-util');
 var source = require('vinyl-source-stream');
@@ -103,6 +104,7 @@ function build() {
     logBuildMode();
 
     return browserify({
+        paths: [ path.join(__dirname, 'src') ],
         entries: ENTRY_FILE,
         debug: true
     })


### PR DESCRIPTION
Adding paths to browserify enables you to do `import RainbowText from 'objects/RainbowText' from the 'GameObjects' directory. Really it just let's you not have to specify relative imports when inside the src directory (which looks much nicer in my opinion).